### PR TITLE
Dlib length

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -24,12 +24,14 @@ if test "$PHP_PDLIB" != "no"; then
   PHP_ADD_LIBRARY(stdc++, 1, PDLIB_SHARED_LIBADD)
   PHP_SUBST(PDLIB_SHARED_LIBADD)
 
-  pdlib_src_files="pdlib.cc \
-  src/chinese_whispers.cc \
-  src/face_detection.cc \
-  src/face_landmark_detection.cc \
-  src/face_recognition.cc \
-  src/cnn_face_detection.cc "
+  pdlib_src_files="
+    pdlib.cc \
+    src/chinese_whispers.cc \
+    src/face_detection.cc \
+    src/face_landmark_detection.cc \
+    src/face_recognition.cc \
+    src/cnn_face_detection.cc \
+    src/vector.cc"
 
   AC_MSG_CHECKING(for pkg-config)
   if test ! -f "$PKG_CONFIG"; then

--- a/pdlib.cc
+++ b/pdlib.cc
@@ -27,12 +27,14 @@ extern "C" {
 	#include "php_ini.h"
 	#include "ext/standard/info.h"
 }
+
 #include "php_pdlib.h"
 #include "src/chinese_whispers.h"
 #include "src/face_detection.h"
 #include "src/face_recognition.h"
 #include "src/cnn_face_detection.h"
 #include "src/face_landmark_detection.h"
+#include "src/vector.h"
 
 /* If you declare any globals in php_pdlib.h uncomment this:
 ZEND_DECLARE_MODULE_GLOBALS(pdlib)
@@ -260,10 +262,11 @@ PHP_MINFO_FUNCTION(pdlib)
  * Every user visible function must have an entry in pdlib_functions[].
  */
 const zend_function_entry pdlib_functions[] = {
-	PHP_FE(confirm_pdlib_compiled,	NULL)
+	PHP_FE(confirm_pdlib_compiled, NULL)
 	PHP_FE(dlib_chinese_whispers, dlib_chinese_whispers_arginfo)
 	PHP_FE(dlib_face_detection, dlib_face_detection_arginfo)
 	PHP_FE(dlib_face_landmark_detection, dlib_face_landmark_detection_arginfo)
+	PHP_FE(dlib_vector_length, dlib_vector_length_arginfo)
 	PHP_FE_END	/* Must be the last line in pdlib_functions[] */
 };
 /* }}} */

--- a/php_pdlib.h
+++ b/php_pdlib.h
@@ -31,7 +31,7 @@ extern "C" {
 extern zend_module_entry pdlib_module_entry;
 #define phpext_pdlib_ptr &pdlib_module_entry
 
-#define PHP_PDLIB_VERSION "1.0.1" /* Replace with version number for your extension */
+#define PHP_PDLIB_VERSION "1.0.2" /* Replace with version number for your extension */
 
 #ifdef PHP_WIN32
 #	define PHP_PDLIB_API __declspec(dllexport)

--- a/src/vector.cc
+++ b/src/vector.cc
@@ -39,7 +39,7 @@ PHP_FUNCTION(dlib_vector_length)
 		elem_x = zend_hash_index_find(Z_ARRVAL_P(x_arg), i);
 		elem_y = zend_hash_index_find(Z_ARRVAL_P(y_arg), i);
 
-		sum += pow(Z_DVAL_P(elem_x) - Z_DVAL_P(elem_y), 2);
+		sum += (Z_DVAL_P(elem_x) - Z_DVAL_P(elem_y))*(Z_DVAL_P(elem_x) - Z_DVAL_P(elem_y));
 	}
 
 	RETURN_DOUBLE(sqrt(sum));

--- a/src/vector.cc
+++ b/src/vector.cc
@@ -1,0 +1,47 @@
+
+#include "../php_pdlib.h"
+
+#include "vector.h"
+
+#include <cmath>
+#include <zend_exceptions.h>
+#include <iostream>
+
+using namespace std;
+
+PHP_FUNCTION(dlib_vector_length)
+{
+	zval *x_arg, *y_arg;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "aa", &x_arg, &y_arg) == FAILURE) {
+		zend_throw_exception_ex(
+			zend_ce_exception,
+			0 TSRMLS_CC,
+			"Unable to parse arrays in dlib_vector_length");
+		return;
+	}
+
+	zval *elem_x, *elem_y;
+	double sum = 0.0;
+	int i, len;
+
+	len = zend_hash_num_elements(Z_ARRVAL_P(x_arg));
+
+	if (len != zend_hash_num_elements(Z_ARRVAL_P(y_arg))) {
+		zend_throw_exception_ex(
+			zend_ce_exception,
+			0 TSRMLS_CC,
+			"The arrays have different sizes");
+		return;
+	}
+
+	for (i = 0 ; i < len ; i++) {
+		elem_x = zend_hash_index_find(Z_ARRVAL_P(x_arg), i);
+		elem_y = zend_hash_index_find(Z_ARRVAL_P(y_arg), i);
+
+		sum += pow(Z_DVAL_P(elem_x) - Z_DVAL_P(elem_y), 2);
+	}
+
+	RETURN_DOUBLE(sqrt(sum));
+}
+

--- a/src/vector.h
+++ b/src/vector.h
@@ -2,8 +2,8 @@
 #define PHP_DLIB_VECTOR_H
 
 ZEND_BEGIN_ARG_INFO_EX(dlib_vector_length_arginfo, 0, 0, 2)
-    ZEND_ARG_INFO(0, x_arg)
-    ZEND_ARG_INFO(0, y_arg)
+    ZEND_ARG_INFO(1, x_arg)
+    ZEND_ARG_INFO(1, y_arg)
 ZEND_END_ARG_INFO()
 PHP_FUNCTION(dlib_vector_length);
 

--- a/src/vector.h
+++ b/src/vector.h
@@ -1,0 +1,10 @@
+#ifndef PHP_DLIB_VECTOR_H
+#define PHP_DLIB_VECTOR_H
+
+ZEND_BEGIN_ARG_INFO_EX(dlib_vector_length_arginfo, 0, 0, 2)
+    ZEND_ARG_INFO(0, x_arg)
+    ZEND_ARG_INFO(0, y_arg)
+ZEND_END_ARG_INFO()
+PHP_FUNCTION(dlib_vector_length);
+
+#endif //PHP_DLIB_VECTOR_H

--- a/tests/vector_length.phpt
+++ b/tests/vector_length.phpt
@@ -4,9 +4,15 @@ Basic tests for dlib_vector_length
 <?php if (!extension_loaded("pdlib")) print "skip"; ?>
 --FILE--
 <?php
-var_dump(dlib_vector_length([0.0, 0.0],       [1.0, 0.0]));
-var_dump(dlib_vector_length([0.0, 0.0, -1.0], [0.0, 0.0, 1.0]));
-var_dump(dlib_vector_length([0.0, 2.5,  1.0], [0.0, 1.0, 1.0]));
+$vectorAL = [0.0, 0.0];
+$vectorAR = [0.0, 1.0];
+var_dump(dlib_vector_length($vectorAL, $vectorAR));
+$vectorBL = [0.0, 0.0, -1.0];
+$vectorBR = [0.0, 0.0, 1.0];
+var_dump(dlib_vector_length($vectorBL, $vectorBR));
+$vectorCL = [0.0, 2.5, 1.0];
+$vectorCR = [0.0, 1.0, 1.0];
+var_dump(dlib_vector_length($vectorCL, $vectorCR));
 ?>
 --EXPECT--
 float(1)

--- a/tests/vector_length.phpt
+++ b/tests/vector_length.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Basic tests for dlib_vector_length
+--SKIPIF--
+<?php if (!extension_loaded("pdlib")) print "skip"; ?>
+--FILE--
+<?php
+var_dump(dlib_vector_length([0.0, 0.0],       [1.0, 0.0]));
+var_dump(dlib_vector_length([0.0, 0.0, -1.0], [0.0, 0.0, 1.0]));
+var_dump(dlib_vector_length([0.0, 2.5,  1.0], [0.0, 1.0, 1.0]));
+?>
+--EXPECT--
+float(1)
+float(2)
+float(1.5)

--- a/tests/version.phpt
+++ b/tests/version.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Just test php extension version
+--SKIPIF--
+<?php if (!extension_loaded("pdlib")) print "skip"; ?>
+--FILE--
+<?php
+var_dump(phpversion('pdlib'));
+?>
+--EXPECT--
+string(5) "1.0.2"


### PR DESCRIPTION
Implement dlib_vector_length to calculate the euclidean distance of the vectors

It not use the 'length' native versions of dlib, due I have to convert the array to the vector, which will take the same time, and then I will use the native method.

In a small benchmark with 1963 descriptors:

 OLD php: 0.012276937961578 Sec.
 New native: 0.0022540950775146 Sec.

This is 80% faster than our PHP class.
